### PR TITLE
Hide VI indicator with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A minimal, aesthetically pleasing fish theme.
 
 * Working directory
 * Current git branch
-* vi mode (requires fish 2.2+)
+* vi mode (requires fish 2.2+ and can be disabled with `set -x TOMITA_VI no`)
 
 > This theme includes a custom vi mode indicator which is built into `fish_prompt`. If you'd like to use vi mode, I recommend adding the following lines to your config.fish:
 >

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,4 +1,5 @@
 function fish_prompt
+  set -l tomita_vi_mode "$TOMITA_VI"
 	echo
 
 	set_color $fish_color_cwd
@@ -6,21 +7,23 @@ function fish_prompt
 
   set_color normal
   printf '%s ' (__fish_git_prompt)
-
-  printf '['
-  switch $fish_bind_mode
-    case default
-      set_color --bold red
-      printf 'n'
-    case insert
-      set_color --bold green
-      printf 'i'
-    case visual
-      set_color --bold magenta
-      printf 'v'
+  
+  if test -z (string match -ri '^no|false|0$' $TOMITA_VI)
+    printf '['
+    switch $fish_bind_mode
+      case default
+        set_color --bold red
+        printf 'n'
+      case insert
+        set_color --bold green
+        printf 'i'
+      case visual
+        set_color --bold magenta
+        printf 'v'
+    end
+    set_color normal
+    printf '] '
   end
-  set_color normal
-  printf '] '
 
   set_color -o yellow
   printf '⋊> '

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -7,8 +7,8 @@ function fish_prompt
 
   set_color normal
   printf '%s ' (__fish_git_prompt)
-  
-  if test -z (string match -ri '^no|false|0$' $TOMITA_VI)
+
+  if test -z (string match -ri '^no|false|0$' $tomita_vi_mode)
     printf '['
     switch $fish_bind_mode
       case default


### PR DESCRIPTION
Hi Dave,

I'm not using the VI mode at all, so this PR is based on some assumptions.
It works fine for my usage since I wanted to keep it as compact as possible.
It might not please everyone, but who knows.